### PR TITLE
Few minor suggestions

### DIFF
--- a/classes/local/type/base/meeting.php
+++ b/classes/local/type/base/meeting.php
@@ -616,19 +616,23 @@ class meeting {
     public function get_moodle_join_url($user, $returnurl = false) {
         $baseurl = \mod_webexactivity\webex::get_base_url();
 
-        $email = str_replace('+', '%2B', $user->email);
-
-        $url = $baseurl.'/m.php?AT=JM&MK='.$this->meetingkey;
-        $url .= '&AE='.$email.'&AN='.$user->firstname.'%20'.$user->lastname;
-        if (isset($this->password)) {
-            $url .= '&PW='.$this->password;
-        }
-
-        if ($returnurl) {
-            $url .= '&BU='.urlencode($returnurl);
-        }
-
-        return $url;
+        $url = $baseurl.'/m.php';
+		$form = '<form name="webexform" action="'.$url.'" method="post">';
+		$form .= '<input type="hidden" name="AT" value="JM">';
+		$form .= '<input type="hidden" name="MK" value="'.$this->meetingkey.'">';
+		$form .= '<input type="hidden" name="AE" value="'.$user->email.'">';
+		$form .= '<input type="hidden" name="AN" value="'.$user->firstname.' '.$user->lastname.'">';
+		if (isset($this->password)) {
+			$form .= '<input type="hidden" name="PW" value="'.$this->password.'">';
+		}
+		if ($returnurl) {
+		    $form .= '<input type="hidden" name="BU" value="'.$returnurl.'">';
+		}
+		$form .= '</form>';
+		$form .= '<script>';
+		$form .= 'window.onload = function(){document.forms["webexform"].submit();}';
+		$form .= '</script>';
+		return $form;
     }
 
     /**

--- a/classes/local/type/base/meeting.php
+++ b/classes/local/type/base/meeting.php
@@ -54,6 +54,7 @@ class meeting {
             'hostwebexid' => null,
             'type' => null,
             'meetingkey' => null,
+            'typecode' => null,
             'guestkey' => null,
             'eventid' => null,
             'hostkey' => null, // Unused?
@@ -645,6 +646,22 @@ class meeting {
         $url = $baseurl.'/k2/j.php?ED='.$this->eventid.'&UID=1';
 
         return $url;
+    }
+    
+    /**
+     * Get the link to switch meeting type for further URL API requests
+     *
+     * @param string     $mtype Meeting type to switch to
+     * @param string     $returnurl The url to return the use to.
+     * @return string    The url for switching meeting type
+     */
+    public function get_switch_mt_ulr($mtype = "MC", $returnurl = false){
+    	$baseurl = \mod_webexactivity\webex::get_base_url();
+    	$url = $baseurl."/o.php?AT=ST&SP=".$mtype;
+    	if ($returnurl) {
+            $url .= '&BU='.urlencode($returnurl);
+        }
+    	return $url;
     }
 
     // ---------------------------------------------------

--- a/classes/local/type/base/xml_gen.php
+++ b/classes/local/type/base/xml_gen.php
@@ -432,7 +432,8 @@ class xml_gen {
      * @return string   The XML.
      */
     public static function time_to_date_string($time) {
-        return date('m/d/Y H:i:s', $time);
+    	$gmttime = $time - date('Z', $time) ; //convert timestamp in server timezone to GMT
+        return date('m/d/Y H:i:s', $gmttime);
     }
 
     /**

--- a/classes/local/type/meeting_center/meeting.php
+++ b/classes/local/type/meeting_center/meeting.php
@@ -56,6 +56,11 @@ class meeting extends \mod_webexactivity\local\type\base\meeting {
      * The meetings type.
      */
     const TYPE = \mod_webexactivity\webex::WEBEXACTIVITY_TYPE_MEETING;
+    
+    /**
+     * The meetings type code.
+     */
+    const TYPE_CODE = 'MC';
 
     /**
      * Builds the meeting object.
@@ -67,6 +72,9 @@ class meeting extends \mod_webexactivity\local\type\base\meeting {
 
         if (!isset($this->type)) {
             $this->type = static::TYPE;
+        }
+        if (!isset($this->typecode)) {
+            $this->typecode = static::TYPE_CODE;
         }
     }
 

--- a/classes/local/type/meeting_center/xml_gen.php
+++ b/classes/local/type/meeting_center/xml_gen.php
@@ -149,6 +149,7 @@ class xml_gen extends \mod_webexactivity\local\type\base\xml_gen {
         if (isset($data->hostwebexid)) {
             $xml .= '<hostWebExID>'.self::format_text($data->hostwebexid).'</hostWebExID>';
         }
+        $xml .= '<timeZoneID>20</timeZoneID>'; //GMT timezone
         $xml .= '</schedule>';
 
         if (isset($data->name)) {

--- a/classes/local/type/training_center/meeting.php
+++ b/classes/local/type/training_center/meeting.php
@@ -51,6 +51,11 @@ class meeting extends \mod_webexactivity\local\type\base\meeting {
      * The meetings type.
      */
     const TYPE = \mod_webexactivity\webex::WEBEXACTIVITY_TYPE_TRAINING;
+    
+    /**
+     * The meetings type code.
+     */
+    const TYPE_CODE = 'TC';
 
     /**
      * Builds the meeting object.
@@ -62,6 +67,9 @@ class meeting extends \mod_webexactivity\local\type\base\meeting {
 
         if (!isset($this->type)) {
             $this->type = static::TYPE;
+        }
+        if (!isset($this->typecode)) {
+            $this->typecode = static::TYPE_CODE;
         }
     }
 

--- a/classes/local/type/training_center/xml_gen.php
+++ b/classes/local/type/training_center/xml_gen.php
@@ -152,6 +152,7 @@ class xml_gen extends \mod_webexactivity\local\type\base\xml_gen {
         if (isset($data->hostwebexid)) {
             $xml .= '<hostWebExID>'.self::format_text($data->hostwebexid).'</hostWebExID>';
         }
+        $xml .= '<timeZoneID>20</timeZoneID>'; //GMT timezone
         $xml .= '</schedule>';
 
         if (isset($data->name)) {

--- a/lang/en/webexactivity.php
+++ b/lang/en/webexactivity.php
@@ -83,7 +83,7 @@ $string['event_recording_created'] = 'Recording created';
 $string['event_recording_deleted'] = 'Recording deleted';
 $string['event_recording_downloaded'] = 'Recording downloaded';
 $string['event_recording_viewed'] = 'Recording viewed';
-$string['externallinktext'] = '<p>This link is for participants who do not have a Oakland University NetID account, or who are not participants in this course. Students in the course will not need to be emailed this link, as they can just click on the Join meeting link on the previous page. This link should be distributed carefully - anybody with this link will be able to access this meeting.  To invite others to the meeting, copy the URL below and send it to them.  If this is a public meeting, this link can also be placed on a web site.</p>';
+$string['externallinktext'] = '<p>This link is for participants who are not enrolled in this course. Students in the course will not need to be emailed this link, as they can just click on the Join meeting link on the previous page. This link should be distributed carefully - anybody with this link will be able to access this meeting.  To invite others to the meeting, copy the URL below and send it to them.  If this is a public meeting, this link can also be placed on a web site.</p>';
 $string['externalpassword'] = 'Participants will also need to know the meeting password: <b>{$a}</b>';
 $string['getexternallink'] = '<a href="{$a->url}">Get external participant link</a>';
 $string['host'] = 'Host';

--- a/view.php
+++ b/view.php
@@ -222,7 +222,6 @@ switch ($action) {
         if (!$webexmeeting->is_available()) {
             break;
         }
-        $joinurl = $webexmeeting->get_moodle_join_url($USER, $returnurl);
 		
 		global $SESSION;
         
@@ -232,7 +231,8 @@ switch ($action) {
 			$switchmturl = $webexmeeting->get_switch_mt_ulr($webexmeeting->typecode, $joinreturnurl);
 			redirect($switchmturl);
         } else {
-        	redirect($joinurl);
+        	$joinurl = $webexmeeting->get_moodle_join_url($USER, $returnurl);
+        	echo $joinurl;
         }
 		
         break;

--- a/view.php
+++ b/view.php
@@ -204,8 +204,17 @@ switch ($action) {
                 \mod_webexactivity\webex::password_redirect($returnurl);
             }
         }
-
-        redirect($authurl);
+		
+		global $SESSION;
+        
+        if($SESSION->mod_webexactivity_sestype != $webexmeeting->typecode){
+        	$SESSION->mod_webexactivity_sestype = $webexmeeting->typecode;
+        	$hostreturnurl = $returnurl."&action=hostmeeting";
+			$switchmturl = $webexmeeting->get_switch_mt_ulr($webexmeeting->typecode, $hostreturnurl);
+			redirect($switchmturl);
+        } else {
+        	redirect($authurl);
+        }
 
         break;
 
@@ -214,8 +223,18 @@ switch ($action) {
             break;
         }
         $joinurl = $webexmeeting->get_moodle_join_url($USER, $returnurl);
-
-        redirect($joinurl);
+		
+		global $SESSION;
+        
+        if($SESSION->mod_webexactivity_sestype != $webexmeeting->typecode){
+        	$SESSION->mod_webexactivity_sestype = $webexmeeting->typecode;
+        	$joinreturnurl = $returnurl."&action=joinmeeting";
+			$switchmturl = $webexmeeting->get_switch_mt_ulr($webexmeeting->typecode, $joinreturnurl);
+			redirect($switchmturl);
+        } else {
+        	redirect($joinurl);
+        }
+		
         break;
 
     case 'viewrecording':


### PR DESCRIPTION
1. Timezone fix - send all timestamps in GMT so the time will be consistent regardless of Moodle server timezone, WebEx account timezone or Moodle user timezone
2. Meeting type switch - allows to subsequently host and join Training Center and Meeting Center sessions without logging out of WebEx
3. Quick fix for upcoming URL API change which allows to submit PW parameter only via POST
4. Small language fix to make the strings more generalized (removed Oakland University mention)